### PR TITLE
Fixed broken URLs for {brms.mmrm}

### DIFF
--- a/bayesian_mmrm_R_package.qmd
+++ b/bayesian_mmrm_R_package.qmd
@@ -12,4 +12,4 @@ source(file = paste(path, "/utils/read_members.R", sep = ""))
 read.members("bayesian_mmrm")
 ```
 
-To learn more about our Bayesian MMRM R package using [`brms`](https://paul-buerkner.github.io/brms/), please visit [rconsortium.github.io/brms.mmrm/](https://rconsortium.github.io/brms.mmrm/).
+To learn more about our Bayesian MMRM R package using [`brms`](https://paul-buerkner.github.io/brms/), please visit [https://openpharma.github.io/brms.mmrm/](https://openpharma.github.io/brms.mmrm/).

--- a/data/news.csv
+++ b/data/news.csv
@@ -10,7 +10,7 @@ Date,Text
 10/03/2023,<a href='./blog/risw2023_session'>Summary of our session at this year’s Regulatory-Industry Statistics Workshop</a>
 9/27/2023,<a href='./blog/new_short_name_and_logo/' title='technology icons'>Announcing the new short name and logo</a>
 7/25/2023,<a href='https://openpharma.github.io/workshop-r-swe-md/'>R Package Workshop in Rockville (MD) on 26th September open for registration</a>
-7/20/2023,<a href='https://rconsortium.github.io/brms.mmrm/' title='brms.mmrm'>{brms.mmrm}</a> R package made public as open-source software (under development).
+7/20/2023,<a href='https://openpharma.github.io/brms.mmrm/' title='brms.mmrm'>{brms.mmrm}</a> R package made public as open-source software (under development).
 4/27/2023,<a href='./bayesian_mmrm_R_package.html'>Bayesian MMRM workstream page launched</a>
 3/9/2023,<a href='https://openpharma.github.io/workshop-r-swe/'>Online workshop in Asia on 24th March open for registration</a>
 3/5/2023,<a href='./hta_page.html'>HTA Workstream is here now</a>


### PR DESCRIPTION
Hi,

This PR fixes some dead URLs for the {brms.mmrm} package (since the package was moved from the `rconsortium` organisation to `openpharma`).
